### PR TITLE
Add official material-theme for Hyper

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,4 @@ Like `awesome-hyper`? Reach out to [@bitandbang](https://twitter.com/bitandbang)
 * [hyper-sierra-vibrancy](https://www.npmjs.com/package/hyper-sierra-vibrancy) - hyper-sierra with vibrancy.
 * [hyper-thirtyone](https://www.npmjs.com/package/hyper-thirtyone) - A slightly modified classic linux terminal theme for Hyper.
 * [hyper-material-theme](https://www.npmjs.com/package/hyper-material-theme) - Dark - The most epic material theme now on Hyper App.
+

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Like `awesome-hyper`? Reach out to [@bitandbang](https://twitter.com/bitandbang)
 * Know of another Hyper package? [Help add it!](https://github.com/bnb/awesome-hyper/issues/new)
 
 # Themes
-* [hyper-material-theme](https://github.com/equinusocio/hyper-material-theme) - Dark - The most epic material theme now on Hyper App.
 * [hyperterm-atom-dark](https://www.npmjs.com/package/hyperterm-atom-dark) - Dark - Really beautiful import of Atom One Dark theme from the [official Atom theme](https://github.com/atom/one-dark-syntax).
 * [hyperblue](https://www.npmjs.com/package/hyperblue) – Dark, cool hues. Turns Hyper blue.
 * [hyperterm-deep-space](https://www.npmjs.com/package/hyperterm-deep-space) - Dark - Dark, muted theme with good color matching.
@@ -127,4 +126,4 @@ Like `awesome-hyper`? Reach out to [@bitandbang](https://twitter.com/bitandbang)
 * [hyper-sierra](https://www.npmjs.com/package/hyper-sierra) - A dark theme for Hyper inspired by the Sierra Nevada.
 * [hyper-sierra-vibrancy](https://www.npmjs.com/package/hyper-sierra-vibrancy) - hyper-sierra with vibrancy.
 * [hyper-thirtyone](https://www.npmjs.com/package/hyper-thirtyone) - A slightly modified classic linux terminal theme for Hyper.
-
+* [hyper-material-theme](https://github.com/equinusocio/hyper-material-theme) - Dark - The most epic material theme now on Hyper App.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Like `awesome-hyper`? Reach out to [@bitandbang](https://twitter.com/bitandbang)
 * Know of another Hyper package? [Help add it!](https://github.com/bnb/awesome-hyper/issues/new)
 
 # Themes
+* [hyper-material-theme](https://github.com/equinusocio/hyper-material-theme) - Dark - The most epic material theme now on Hyper App.
 * [hyperterm-atom-dark](https://www.npmjs.com/package/hyperterm-atom-dark) - Dark - Really beautiful import of Atom One Dark theme from the [official Atom theme](https://github.com/atom/one-dark-syntax).
 * [hyperblue](https://www.npmjs.com/package/hyperblue) – Dark, cool hues. Turns Hyper blue.
 * [hyperterm-deep-space](https://www.npmjs.com/package/hyperterm-deep-space) - Dark - Dark, muted theme with good color matching.

--- a/README.md
+++ b/README.md
@@ -126,4 +126,4 @@ Like `awesome-hyper`? Reach out to [@bitandbang](https://twitter.com/bitandbang)
 * [hyper-sierra](https://www.npmjs.com/package/hyper-sierra) - A dark theme for Hyper inspired by the Sierra Nevada.
 * [hyper-sierra-vibrancy](https://www.npmjs.com/package/hyper-sierra-vibrancy) - hyper-sierra with vibrancy.
 * [hyper-thirtyone](https://www.npmjs.com/package/hyper-thirtyone) - A slightly modified classic linux terminal theme for Hyper.
-* [hyper-material-theme](https://github.com/equinusocio/hyper-material-theme) - Dark - The most epic material theme now on Hyper App.
+* [hyper-material-theme](https://www.npmjs.com/package/hyper-material-theme) - Dark - The most epic material theme now on Hyper App.


### PR DESCRIPTION
- [x] The title for my package or theme uses its npm title (`hyper-plugin-example`)
- [x] The link for my package or theme uses the npmjs.com link (https://www.npmjs.com/package/hyper-material-theme)
- [x] Put your awesome item at the **BOTTOM** of the correct (plugin, theme, or resource) list.
- [x] There is a visual representation of what my plugin or theme does in the repo. (Plugin: screenshot or gif || Theme: screenshot of the theme applied to Hyper)
- [x] **VERY IMPORTANT:** I've written a short (one sentence) description for my package or theme as the description of the awesome plugin, theme, or resource in the README.md file I'm submitting in the PR.

This is the official [Material Theme](https://github.com/equinusocio/material-theme) porting for Hyper.