### PR TITLE
Missing section `Resources` and theme browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [<img src="https://raw.githubusercontent.com/bnb/awesome-hyper/master/Hyper-Mark-Large.png" align="right" width="240">](https://hyper.is)
 
-> A curated list of sweet Hyper [packages](#packages), [themes](#themes), and [resources](#resources).
+> A curated list of sweet Hyper [packages](#packages) and [themes](#themes).
 
 *Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing. You might also like [awesome-node](https://github.com/sindresorhus/awesome-nodejs) and [awesome-npm](https://github.com/sindresorhus/awesome-npm), which both have CLI stuff you can use with Hyper!*
 
@@ -24,7 +24,6 @@ Like `awesome-hyper`? Reach out to [@bitandbang](https://twitter.com/bitandbang)
 
 - [Packages](#packages)
 - [Themes](#themes)
-- [Resources](#resources)
 
 # Packages
 * [hpm-cli](https://www.npmjs.com/package/hpm-cli) - A plugin manager for Hyper.
@@ -70,6 +69,9 @@ Like `awesome-hyper`? Reach out to [@bitandbang](https://twitter.com/bitandbang)
 * Know of another Hyper package? [Help add it!](https://github.com/bnb/awesome-hyper/issues/new)
 
 # Themes
+
+> *Also check the [Hyper Themes screenshot browser](https://hyperthemes.matthi.coffee)*
+
 * [hyperterm-atom-dark](https://www.npmjs.com/package/hyperterm-atom-dark) - Dark - Really beautiful import of Atom One Dark theme from the [official Atom theme](https://github.com/atom/one-dark-syntax).
 * [hyperblue](https://www.npmjs.com/package/hyperblue) – Dark, cool hues. Turns Hyper blue.
 * [hyperterm-deep-space](https://www.npmjs.com/package/hyperterm-deep-space) - Dark - Dark, muted theme with good color matching.


### PR DESCRIPTION
The section ressources has somehow disappeared recently. I've removed the links to it and added the theme browser link back – you can remove it again if you feel it doesn't add value.

All the best!

<!--- Provide a general summary of your changes in the Title above -->

## Checklist for submitting an `awesome` plugin, theme, or resource:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- More detailed instructions are in the CONTRIBUTING.md document - please read it if you have a question!-->
<!--- If you're still unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The title for my package or theme uses its npm title (`hyper-plugin-example`)
- [ ] The link for my package or theme uses the npmjs.com link (https://www.npmjs.com/package/hyper-plugin-example)
- [ ] There is a visual representation of what my plugin or theme does in the repo. (Plugin: screenshot or gif || Theme: screenshot of the theme applied to Hyper)
- [ ] Put your awesome item at the **BOTTOM** of the correct (plugin, theme, or resource) list.
- [ ] **VERY IMPORTANT:** I've written a short (one sentence) description for my package or theme as the description of the awesome plugin, theme, or resource in the README.md file I'm submitting in the PR.
