### PR TITLE
Add new `hyper-mac-controls` to customization section

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Know of another Hyper package? [Help add it!](https://github.com/bnb/awesome-hyp
 * [hyperminimal](https://www.npmjs.com/package/hyperminimal) - Removes the window header for more space and less distraction.
 * [hyper-autoprofile](https://www.npmjs.com/package/hyper-autoprofile) - Change terminal appearance (backgroundColor, font...) according to current shell prompt.
 * [hyper-tabs-enhanced](https://www.npmjs.com/package/hyper-tabs-enhanced) - Configurable enhanced tabs with tab icons and more.
-* [hyper-mac-controls](https://www.npmjs.com/package/hyper-mac-controls) - Mac-like window controls for HyperTerm.
+* [hyper-mac-controls](https://www.npmjs.com/package/hyper-mac-controls) - Mac-like window controls for Hyper.
 
 ## Development
 * [hyperterm-open-devtools](https://www.npmjs.com/package/hyperterm-open-devtools) - Open DevTools for currently showing web page with a hotkey.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Know of another Hyper package? [Help add it!](https://github.com/bnb/awesome-hyp
 * [hyperminimal](https://www.npmjs.com/package/hyperminimal) - Removes the window header for more space and less distraction.
 * [hyper-autoprofile](https://www.npmjs.com/package/hyper-autoprofile) - Change terminal appearance (backgroundColor, font...) according to current shell prompt.
 * [hyper-tabs-enhanced](https://www.npmjs.com/package/hyper-tabs-enhanced) - Configurable enhanced tabs with tab icons and more.
+* [hyperterm-mac-tabs](https://www.npmjs.com/package/hyperterm-mac-controls) - Mac-like window controls for HyperTerm.
 
 ## Development
 * [hyperterm-open-devtools](https://www.npmjs.com/package/hyperterm-open-devtools) - Open DevTools for currently showing web page with a hotkey.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Know of another Hyper package? [Help add it!](https://github.com/bnb/awesome-hyp
 * [hyperminimal](https://www.npmjs.com/package/hyperminimal) - Removes the window header for more space and less distraction.
 * [hyper-autoprofile](https://www.npmjs.com/package/hyper-autoprofile) - Change terminal appearance (backgroundColor, font...) according to current shell prompt.
 * [hyper-tabs-enhanced](https://www.npmjs.com/package/hyper-tabs-enhanced) - Configurable enhanced tabs with tab icons and more.
-* [hyperterm-mac-tabs](https://www.npmjs.com/package/hyperterm-mac-controls) - Mac-like window controls for HyperTerm.
+* [hyper-mac-controls](https://www.npmjs.com/package/hyper-mac-controls) - Mac-like window controls for HyperTerm.
 
 ## Development
 * [hyperterm-open-devtools](https://www.npmjs.com/package/hyperterm-open-devtools) - Open DevTools for currently showing web page with a hotkey.


### PR DESCRIPTION
Make the hyperterm close, minimize and maximize buttons look like a mac.

Link to repo: [hyper-mac-controls](https://github.com/krve/hyper-mac-controls)

<!--- Provide a general summary of your changes in the Title above -->

## Checklist for submitting an `awesome` plugin, theme, or resource:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- More detailed instructions are in the CONTRIBUTING.md document - please read it if you have a question!-->
<!--- If you're still unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The title for my package or theme uses its npm title (`hyper-plugin-example`)
- [x] The link for my package or theme uses the npmjs.com link (https://www.npmjs.com/package/hyper-plugin-example)
- [x] There is a visual representation of what my plugin or theme does in the repo. (Plugin: screenshot or gif || Theme: screenshot of the theme applied to Hyper)
- [x] Put your awesome item at the **BOTTOM** of the correct (plugin, theme, or resource) list.
- [x] **VERY IMPORTANT:** I've written a short (one sentence) description for my package or theme as the description of the awesome plugin, theme, or resource in the README.md file I'm submitting in the PR.
