### PR TITLE
change name hyperterm-base16-ocean-saturated

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Know of another Hyper package? [Help add it!](https://github.com/bnb/awesome-hyp
 * [hypersolar-dark](https://www.npmjs.com/package/hypersolar-dark) - A dark theme based loosely on Solarized Dark, with a fix for the usual solarized dark colours with blacks that actually show up in your terminal!
 * [hyperterm-earthsong](https://www.npmjs.com/package/hyperterm-earthsong) - A natural and calming theme for Hyper. Ported from iTerm's Earthsong theme
 * [hyperterm-retro](https://www.npmjs.com/package/hyperterm-retro) - A retro Hyper theme inspired by the [cool-retro-term](https://github.com/Swordfish90/cool-retro-term) terminal emulator.
-* [hyperterm-base16-ocean-saturated](https://www.npmjs.com/package/hyperterm-base16-ocean-saturated) - Dark - Elegant theme with saturated colors.
+* [hyper-oceans16](https://www.npmjs.com/package/hyper-oceans16) - Saturated theme based on Base16 Ocean syntax.
 * [hyperterm-adventurous](https://www.npmjs.com/package/hyperterm-adventurous) - An adventure time inspired theme based on the Adventurous Atom theme.
 * [hyperterm-hipster](https://www.npmjs.com/package/hyperterm-hipster) - A hipster theme based on the hipster-syntax theme for Atom.
 * [hyper-flat](https://www.npmjs.com/package/hyper-flat) - A Flat theme for Hyper.


### PR DESCRIPTION
updated to accurate name from hyperterm-base16-ocean-saturated to hyper-oceans16 and more fitting description

<!--- Provide a general summary of your changes in the Title above -->

## Checklist for submitting an `awesome` plugin, theme, or resource:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- More detailed instructions are in the CONTRIBUTING.md document - please read it if you have a question!-->
<!--- If you're still unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The title for my package or theme uses its npm title (`hyper-plugin-example`)
- [x] The link for my package or theme uses the npmjs.com link (https://www.npmjs.com/package/hyper-plugin-example)
- [x] There is a visual representation of what my plugin or theme does in the repo. (Plugin: screenshot or gif || Theme: screenshot of the theme applied to Hyper)
- [x] Put your awesome item at the **BOTTOM** of the correct (plugin, theme, or resource) list.
- [x] **VERY IMPORTANT:** I've written a short (one sentence) description for my package or theme as the description of the awesome plugin, theme, or resource in the README.md file I'm submitting in the PR.
