### PR TITLE
Remove (again) deprecated hyperterm-tab-cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Know of another Hyper package? [Help add it!](https://github.com/bnb/awesome-hyp
 * [hyperterm-tabs](https://www.npmjs.com/package/hyperterm-tabs) - Rearrange tabs by drag&dropping them.
 * [hyperterm-focus-reporting](https://www.npmjs.com/package/hyperterm-focus-reporting) - Adds focus reporting to Hyper - similar to iTerm2.
 * [hyperlinks](https://www.npmjs.com/package/hyperlinks) - Extension for Hyper that automatically links URLs.
-* [hyperterm-tab-cwd](https://www.npmjs.com/package/hyperterm-tab-cwd) - Add the current working directory to the header tabs in Hyper.
 * [hyper-statusline](https://www.npmjs.com/package/hyper-statusline) - Status line showing current cwd and git branch status.
 * [hypernpm](https://www.npmjs.com/package/hypernpm) - Use keyboard shortcuts to run npm script commands.
 * [hyper-startup](https://www.npmjs.com/package/hyper-startup) - Executes any configured commands when Hyper loads.


### PR DESCRIPTION
The link to hyperterm-tab-cwd was removed in https://github.com/bnb/awesome-hyper/pull/161 but later reintroduced in https://github.com/bnb/awesome-hyper/commit/2a518e84f9eac0ff2f442afa7534c929d2255c88. I didn't check if the latter introduced other regressions.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist for submitting an `awesome` plugin, theme, or resource:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- More detailed instructions are in the CONTRIBUTING.md document - please read it if you have a question!-->
<!--- If you're still unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The title for my package or theme uses its npm title (`hyper-plugin-example`)
- [ ] The link for my package or theme uses the npmjs.com link (https://www.npmjs.com/package/hyper-plugin-example)
- [ ] There is a visual representation of what my plugin or theme does in the repo. (Plugin: screenshot or gif || Theme: screenshot of the theme applied to Hyper)
- [ ] Put your awesome item at the **BOTTOM** of the correct (plugin, theme, or resource) list.
- [ ] **VERY IMPORTANT:** I've written a short (one sentence) description for my package or theme as the description of the awesome plugin, theme, or resource in the README.md file I'm submitting in the PR.
