### PR TITLE
Add hyperterm-gruvbox theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Know of another Hyper package? [Help add it!](https://github.com/bnb/awesome-hyp
 * [hyper-nord](https://www.npmjs.com/package/hyper-nord) - Nord theme for Hyper.
 * [hyper-captain-sweetheart](https://www.npmjs.com/package/hyper-captain-sweetheart) - Tuff but sweet Hyper theme.
 * [hyper-midnight](https://www.npmjs.com/package/hyper-midnight) - A minimalist theme for the Hyper terminal.
+* [hyperterm-gruvbox](https://www.npmjs.com/package/hyperterm-gruvbox) - Theme based on gruvbox with dark, light styles and contrast options.
 * Know of another really awesome theme? [Get it on awesome-hyper!](https://github.com/bnb/awesome-hyper/issues/new)
 
 [⬆ Back to top](#contents)


### PR DESCRIPTION
Theme based on gruvbox with dark, light styles and contrast options.
https://www.npmjs.com/package/hyperterm-gruvbox

- [x] The title for my package or theme uses its npm title (`hyper-plugin-example`)
- [x] The link for my package or theme uses the npmjs.com link (https://www.npmjs.com/package/hyper-plugin-example)
- [x] There is a visual representation of what my plugin or theme does in the repo. (Plugin: screenshot or gif || Theme: screenshot of the theme applied to Hyper)
- [x] Put your awesome item at the **BOTTOM** of the correct (plugin, theme, or resource) list.
- [x] **VERY IMPORTANT:** I've written a short (one sentence) description for my package or theme as the description of the awesome plugin, theme, or resource in the README.md file I'm submitting in the PR.