### PR TITLE
Make repository in package.json mandatory

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@
 
 - [ ] **Title:** The title for the addition uses its npm title (`hyper-example`) or the resource's title.
 - [ ] **Link:** The link for the addition uses the npmjs.com link (`https://www.npmjs.com/package/hyper-example`) or the resource's full URI.
+- [ ] **Repository:** The `package.json` file of the resource contains repository informations.
 - [ ] **Visual:** There is a visual representation of what the addition does in the addition's source repository.
 - [ ] **Location:** The awesome addition is at the **BOTTOM** of the correct category or sub-category.
   - If it's a plugin or resource, put your awesome item at the **BOTTOM** of the correct section.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 - [ ] **Title:** The title for the addition uses its npm title (`hyper-example`) or the resource's title.
 - [ ] **Link:** The link for the addition uses the npmjs.com link (`https://www.npmjs.com/package/hyper-example`) or the resource's full URI.
-- [ ] **Repository:** The `package.json` file of the resource contains repository informations.
+- [ ] **Repository:** The `package.json` file of the resource contains repository information.
 - [ ] **Visual:** There is a visual representation of what the addition does in the addition's source repository.
 - [ ] **Location:** The awesome addition is at the **BOTTOM** of the correct category or sub-category.
   - If it's a plugin or resource, put your awesome item at the **BOTTOM** of the correct section.


### PR DESCRIPTION
It makes easier to find source code from npmjs

I'm using awesome-hyper to have a list of known plugins.
For a breaking change in `Hyper`, it permits to check all plugins repo and grep them to search impacted ones.
But for this, I need to retrieve source code. Without a repository entry in `package.json`, I can't use `npm view $plugin repository.url`.

I made PRs to correct these already listed plugins:
* hyperdocs
* hyperborder
* hyper-wal
* hyperpower
* hyper-white-theme
* hyper-zigorat
* hyperpanic
* hyperterm-cobalt2-theme
* hyperterm-colors
* hyperterm-electron-highlighter
* hyperterm-material-spacegray
* hyperterm-panda 