### PR TITLE
Fix header links on Github Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <p>Want to add your awesome Hyper package, theme, or resource? Make the change and <a href="https://opensource.guide/how-to-contribute/#opening-a-pull-request">open a pull request</a>!</p>
 <p>Like <code>awesome-hyper</code>? Reach out to <a href="https://twitter.com/bitandbang">@bitandbang</a>, <a href="https://twitter.com/matheusfrndes">@matheusfrndes</a>, and <a href="https://twitter.com/iamstarkov">@iamstarkov</a> on Twitter and say <em>hi</em>! 👋</p>
 
-<h1>Contents</h1>
+<h1 id="contents">Contents</h1>
 <ul>
 <li><a href="#packages">Packages</a><ul>
 <li><a href="#productivity">Productivity</a></li>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 <li><a href="#themes">Themes</a></li>
 <li><a href="#resources">Resources</a></li>
 </ul>
-<h1>Packages</h1>
+<h1 id="packages">Packages</h1>
 <p>Know of another Hyper package? <a href="https://github.com/bnb/awesome-hyper/issues/new">Help add it!</a></p>
 <h2 id="productivity">Productivity</h2>
 <table>
@@ -323,7 +323,7 @@
 </tbody>
 </table>
 <p><a href="#contents">⬆ Back to top</a></p>
-<h1>Themes</h1>
+<h1 id="themes">Themes</h1>
 <table>
 <thead>
 <tr>
@@ -652,7 +652,7 @@
 </table>
 <p>Know of another really awesome theme? <a href="https://github.com/bnb/awesome-hyper/issues/new">Get it on awesome-hyper!</a></p>
 <p><a href="#contents">⬆ Back to top</a></p>
-<h1>Resources</h1>
+<h1 id="resources">Resources</h1>
 <ul>
 <li><a href="https://hyper.is/">Official Hyper Website</a> - The official Hyper website.</li>
 <li><a href="https://www.npmjs.com/package/hyperzsh">hyperzsh</a> - Zsh for Hyper.</li>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 </ul>
 <h1>Packages</h1>
 <p>Know of another Hyper package? <a href="https://github.com/bnb/awesome-hyper/issues/new">Help add it!</a></p>
-<h2>Productivity</h2>
+<h2 id="productivity">Productivity</h2>
 <table>
 <thead>
 <tr>
@@ -127,7 +127,7 @@
 </tbody>
 </table>
 <p><a href="#contents">⬆ Back to top</a></p>
-<h2>Customization</h2>
+<h2 id="customization">Customization</h2>
 <table>
 <thead>
 <tr>
@@ -267,7 +267,7 @@
 </tbody>
 </table>
 <p><a href="#contents">⬆ Back to top</a></p>
-<h2>Development</h2>
+<h2 id="development">Development</h2>
 <table>
 <thead>
 <tr>
@@ -291,7 +291,7 @@
 </tbody>
 </table>
 <p><a href="#contents">⬆ Back to top</a></p>
-<h2>Fun</h2>
+<h2 id="fun">Fun</h2>
 <table>
 <thead>
 <tr>


### PR DESCRIPTION
Links were not working when navigating from Contents ➡️  Header sections and vice versa. Just added the correct `id` attributes to the headers so `<a href="blah">` link tags worked correctly.