### PR TITLE
Added 'hyper-native-window-decoration' to list of customization plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Name and description | Downloads
 [hyper-background](https://www.npmjs.com/package/hyper-background) - Change the background of your Hyper terminal! | [![npm](https://img.shields.io/npm/dm/hyper-background.svg?label=DL)](https://www.npmjs.com/package/hyper-background)
 [hyper-vertical-tabs](https://www.npmjs.com/package/hyper-vertical-tabs) - Put the tabs on a sidebar to the left, as is possible in iTerm2 and ROXTerm. | [![npm](https://img.shields.io/npm/dm/hyper-vertical-tabs.svg?label=DL)](https://www.npmjs.com/package/hyper-vertical-tabs)
 [themer](https://www.npmjs.com/package/themer) - Generate themes for Hyper and all your other development tools | [![npm](https://img.shields.io/npm/dm/themer.svg?label=DL)](https://www.npmjs.com/package/themer)
+[hyper-native-window-dectoration](https://www.npmjs.com/package/hyper-native-window-decoration) - Native window decorations in HyperTerm. | [![npm](https://img.shields.io/npm/dm/hyper-native-window-dectoration.svg?label=DL)](https://www.npmjs.com/package/hyper-native-window-dectoration)
 
 [⬆ Back to top](#contents)
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Name and description | Downloads
 [hyper-background](https://www.npmjs.com/package/hyper-background) - Change the background of your Hyper terminal! | [![npm](https://img.shields.io/npm/dm/hyper-background.svg?label=DL)](https://www.npmjs.com/package/hyper-background)
 [hyper-vertical-tabs](https://www.npmjs.com/package/hyper-vertical-tabs) - Put the tabs on a sidebar to the left, as is possible in iTerm2 and ROXTerm. | [![npm](https://img.shields.io/npm/dm/hyper-vertical-tabs.svg?label=DL)](https://www.npmjs.com/package/hyper-vertical-tabs)
 [themer](https://www.npmjs.com/package/themer) - Generate themes for Hyper and all your other development tools | [![npm](https://img.shields.io/npm/dm/themer.svg?label=DL)](https://www.npmjs.com/package/themer)
-[hyper-native-window-dectoration](https://www.npmjs.com/package/hyper-native-window-decoration) - Native window decorations in HyperTerm. | [![npm](https://img.shields.io/npm/dm/hyper-native-window-dectoration.svg?label=DL)](https://www.npmjs.com/package/hyper-native-window-dectoration)
+[hyper-native-window-decoration](https://www.npmjs.com/package/hyper-native-window-decoration) - Native window decorations in HyperTerm. | [![npm](https://img.shields.io/npm/dm/hyper-native-window-decoration.svg?label=DL)](https://www.npmjs.com/package/hyper-native-window-decoration)
 
 [⬆ Back to top](#contents)
 


### PR DESCRIPTION
Native window decorations in HyperTerm.

Hyper uses it's own client-side decorations, and unless you're on a Mac, these decorations don't fit in well with the rest of the desktop environment. Using the platform's native window decorations is an easy way to make the terminal blend in.

## Checklist for submitting a resource to `awesome-hyper`:

- [x] **Title:** The title for the addition uses its npm title (`hyper-example`) or the resource's title.
- [x] **Link:** The link for the addition uses the npmjs.com link (`https://www.npmjs.com/package/hyper-example`) or the resource's full URI.
- [x] **Repository:** The `package.json` file of the resource contains [repository information](https://docs.npmjs.com/files/package.json#repository).
- [x] **Visual:** There is a visual representation of what the addition does in its source repository.
- [x] **Location:** The awesome addition is in the correct category or sub-category.
  - If it's a **plugin or resource**, put your awesome item at the **BOTTOM** of the correct section.
  - If it's a **theme**, insert it according to the **ALPHABETICAL** order.
- [x] **Description:** I've written a short (one sentence) description for the addition in the `README.md`.
- [x] **Downloads:** I've added a download stats badge in the second column (`[![npm](https://img.shields.io/npm/dm/hyper-example.svg?label=DL)]()`)
