### PR TITLE
hyperterm-1password no longer works

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Name and description | Downloads
 -------------------- | -------------
 [hyperline](https://www.npmjs.com/package/hyperline) - A status line at the bottom of your Hyper! | [![npm](https://img.shields.io/npm/dm/hyperline.svg?label=DL)](https://www.npmjs.com/package/hyperline)
 [hypercwd](https://www.npmjs.com/package/hypercwd) - Open new tabs with the same directory as your current tab. | [![npm](https://img.shields.io/npm/dm/hypercwd.svg?label=DL)](https://www.npmjs.com/package/hypercwd)
-[hyperterm-1password](https://www.npmjs.com/package/hyperterm-1password) - Integration with 1Password (password manager). | [![npm](https://img.shields.io/npm/dm/hyperterm-1password.svg?label=DL)](https://www.npmjs.com/package/hyperterm-1password)
 [hyperterm-visor](https://www.npmjs.com/package/hyperterm-visor) - Show/hide your Hyper terminal with a global hotkey & more. | [![npm](https://img.shields.io/npm/dm/hyperterm-visor.svg?label=DL)](https://www.npmjs.com/package/hyperterm-visor)
 [hyper-sync-settings](https://www.npmjs.com/package/hyper-sync-settings) - Easy way to backup and restore Hyper settings to Github. | [![npm](https://img.shields.io/npm/dm/hyper-sync-settings.svg?label=DL)](https://www.npmjs.com/package/hyper-sync-settings)
 [hyperterm-summon](https://www.npmjs.com/package/hyperterm-summon) - Summon your Hyper windows with a system-wide hotkey. | [![npm](https://img.shields.io/npm/dm/hyperterm-summon.svg?label=DL)](https://www.npmjs.com/package/hyperterm-summon)


### PR DESCRIPTION
1Password removed the functionality a while back.

<!--- Provide a general summary of your changes in the Title above -->

## Checklist for submitting a resource to `awesome-hyper`:

<!--- Go over all the following points, and put an `x` in all the boxes that have been completed. -->
<!--- More detailed instructions are in the project's CONTRIBUTING.md - please read it if you have a question!-->
<!--- If you're still unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] **Title:** The title for the addition uses its npm title (`hyper-example`) or the resource's title.
- [ ] **Link:** The link for the addition uses the npmjs.com link (`https://www.npmjs.com/package/hyper-example`) or the resource's full URI.
- [ ] **Repository:** The `package.json` file of the resource contains [repository information](https://docs.npmjs.com/files/package.json#repository).
- [ ] **Visual:** There is a visual representation of what the addition does in its source repository.
- [ ] **Location:** The awesome addition is in the correct category or sub-category.
  - If it's a **plugin or resource**, put your awesome item at the **BOTTOM** of the correct section.
  - If it's a **theme**, insert it according to the **ALPHABETICAL** order.
- [ ] **Description:** I've written a short (one sentence) description for the addition in the `README.md`.
- [ ] **Downloads:** I've added a download stats badge in the second column (`[![npm](https://img.shields.io/npm/dm/hyper-example.svg?label=DL)]()`)
