### PR TITLE
Fix PR helper article url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,4 +50,4 @@ You'll need to have a GitHub account - you can [register here](https://github.co
 
 Sometimes, the maintainers of awesome-hyper will ask you to edit your Pull Request before it is included. This is normally due to spelling errors or because your PR didn't match the awesome-hyper list guidelines. We're always happy to help in any way we can.
 
-[Here](https://github.com/RichardLitt/docs/blob/master/amending-a-commit-guide.md) is a write up on how to change a Pull Request, and the different ways you can do that.
+[Here](https://github.com/RichardLitt/knowledge/blob/master/github/amending-a-commit-guide.md) is a write up on how to change a Pull Request, and the different ways you can do that.


### PR DESCRIPTION
URL was no longer working since the file's repository name has changed.

