### PR TITLE
Add hyper-custom-touchbar plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Name and description | Downloads
 [hyper-folder-icon](https://www.npmjs.com/package/hyper-folder-icon) - Show custom folder's icon for Mac and Linux in tabs. | [![npm](https://img.shields.io/npm/dm/hyper-folder-icon.svg?label=DL)](https://www.npmjs.com/package/hyper-folder-icon)
 [hyper-tab-touchbar](https://www.npmjs.com/package/hyper-tab-touchbar) - See and access your terminal tabs from the MacBook Pro Touchbar. Supports icons with `hyper-folder-icon`. | [![npm](https://img.shields.io/npm/dm/hyper-tab-touchbar.svg?label=DL)](https://www.npmjs.com/package/hyper-tab-touchbar)
 [hyper-opacity](https://www.npmjs.com/package/hyper-opacity) - Set the opacity of your Hyper window. | [![npm](https://img.shields.io/npm/dm/hyper-opacity.svg?label=DL)](https://www.npmjs.com/package/hyper-opacity)
+[hyper-custom-touchbar](https://www.npmjs.com/package/hyper-custom-touchbar) - Add custom buttons in Macbook's Touch Bar. | [![npm](https://img.shields.io/npm/dm/hyper-custom-touchbar.svg?label=DL)](https://www.npmjs.com/package/hyper-custom-touchbar)
 
 [⬆ Back to top](#contents)
 


### PR DESCRIPTION
Added https://github.com/SwarShah/hyper-custom-touchbar which allows the user to add custom buttons in Macbook's Touch Bar.

## Checklist for submitting a resource to `awesome-hyper`:

- [x] **Title:** The title for the addition uses its npm title (`hyper-example`) or the resource's title.
- [x] **Link:** The link for the addition uses the npmjs.com link (`https://www.npmjs.com/package/hyper-example`) or the resource's full URI.
- [x] **Repository:** The `package.json` file of the resource contains [repository information](https://docs.npmjs.com/files/package.json#repository).
- [x] **Visual:** There is a visual representation of what the addition does in its source repository.
- [x] **Location:** The awesome addition is in the correct category or sub-category.
  - If it's a **plugin or resource**, put your awesome item at the **BOTTOM** of the correct section.
  - If it's a **theme**, insert it according to the **ALPHABETICAL** order.
- [x] **Description:** I've written a short (one sentence) description for the addition in the `README.md`.
- [x] **Downloads:** I've added a download stats badge in the second column (`[![npm](https://img.shields.io/npm/dm/hyper-example.svg?label=DL)]()`)
