### PR TITLE
Add hyper-save-windowstate plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Name and description | Downloads
 [hyper-tab-touchbar](https://www.npmjs.com/package/hyper-tab-touchbar) - See and access your terminal tabs from the MacBook Pro's Touch Bar. Supports icons with `hyper-folder-icon`. | [![npm](https://img.shields.io/npm/dm/hyper-tab-touchbar.svg?label=DL)](https://www.npmjs.com/package/hyper-tab-touchbar)
 [hyper-opacity](https://www.npmjs.com/package/hyper-opacity) - Set the opacity of your Hyper window. | [![npm](https://img.shields.io/npm/dm/hyper-opacity.svg?label=DL)](https://www.npmjs.com/package/hyper-opacity)
 [hyper-custom-touchbar](https://www.npmjs.com/package/hyper-custom-touchbar) - Add custom buttons in MacBook Pro's Touch Bar. | [![npm](https://img.shields.io/npm/dm/hyper-custom-touchbar.svg?label=DL)](https://www.npmjs.com/package/hyper-custom-touchbar)
+[hyper-save-windowstate](https://www.npmjs.com/package/hyper-save-windowstate) - Save and restore Hyper window position/size after restart. | [![npm](https://img.shields.io/npm/dm/hyper-save-windowstate.svg?label=DL)](https://www.npmjs.com/package/hyper-save-windowstate)
 
 [⬆ Back to top](#contents)
 


### PR DESCRIPTION
Add `hyper-save-windowstate` plugin to plugin list. `hyper-save-windowstate` saves and restores Hyper window position/size after restart.

## Checklist for submitting a resource to `awesome-hyper`:

<!--- Go over all the following points, and put an `x` in all the boxes that have been completed. -->
<!--- More detailed instructions are in the project's CONTRIBUTING.md - please read it if you have a question!-->
<!--- If you're still unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] **Title:** The title for the addition uses its npm title (`hyper-example`) or the resource's title.
- [x] **Link:** The link for the addition uses the npmjs.com link (`https://www.npmjs.com/package/hyper-example`) or the resource's full URI.
- [x] **Repository:** The `package.json` file of the resource contains [repository information](https://docs.npmjs.com/files/package.json#repository).
- [ ] **Visual:** There is a visual representation of what the addition does in its source repository.
- [x] **Location:** The awesome addition is in the correct category or sub-category.
  - If it's a **plugin or resource**, put your awesome item at the **BOTTOM** of the correct section.
  - If it's a **theme**, insert it according to the **ALPHABETICAL** order.
- [x] **Description:** I've written a short (one sentence) description for the addition in the `README.md`.
- [x] **Downloads:** I've added a download stats badge in the second column (`[![npm](https://img.shields.io/npm/dm/hyper-example.svg?label=DL)]()`)

I haven't added a visual representation of what my plugin does because its kind of self-explaining, so don't think it would be particularly helpful.