### PR TITLE
Add hyperduck

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Name and description | Downloads
 [hyperdocs](https://www.npmjs.com/package/hyperdocs) - Get documentation pages right in your terminal. | [![npm](https://img.shields.io/npm/dm/hyperdocs.svg?label=DL)](https://www.npmjs.com/package/hyperdocs)
 [hyper-search](https://www.npmjs.com/package/hyper-search) - Search text in your terminal. | [![npm](https://img.shields.io/npm/dm/hyper-search.svg?label=DL)](https://www.npmjs.com/package/hyper-search)
 [hypergoogle](https://www.npmjs.com/package/hypergoogle) - Search Google from your terminal. | [![npm](https://img.shields.io/npm/dm/hypergoogle.svg?label=DL)](https://www.npmjs.com/package/hypergoogle)
+[hyperduck](https://www.npmjs.com/package/hyperduck) - Search DuckDuckGo from your terminal. | [![npm](https://img.shields.io/npm/dm/hyperduck.svg?label=DL)](https://www.npmjs.com/package/hyperduck)
 [hyper-quit](https://www.npmjs.com/package/hyper-quit) - Quit Hyper on macOS when last window closes. | [![npm](https://img.shields.io/npm/dm/hyper-quit.svg?label=DL)](https://www.npmjs.com/package/hyper-quit)
 [hyper-confirm](https://www.npmjs.com/package/hyper-confirm) - Displays a confirmation dialog before quitting Hyper. | [![npm](https://img.shields.io/npm/dm/hyper-confirm.svg?label=DL)](https://www.npmjs.com/package/hyper-confirm)
 [hyper-match](https://www.npmjs.com/package/hyper-match) - Links patterns such as urls, emails and file paths to configured commands. | [![npm](https://img.shields.io/npm/dm/hyper-match.svg?label=DL)](https://www.npmjs.com/package/hyper-match)


### PR DESCRIPTION
Added [hyperduck](https://github.com/benseven/hyperduck), which is a hypergoogle fork for DuckDuckGo.

## Checklist for submitting a resource to `awesome-hyper`:
- [x] **Title:** The title for the addition uses its npm title (`hyper-example`) or the resource's title.
- [x] **Link:** The link for the addition uses the npmjs.com link (`https://www.npmjs.com/package/hyper-example`) or the resource's full URI.
- [x] **Repository:** The `package.json` file of the resource contains [repository information](https://docs.npmjs.com/files/package.json#repository).
- [x] **Visual:** There is a visual representation of what the addition does in its source repository.
- [x] **Location:** The awesome addition is in the correct category or sub-category.
  - If it's a **plugin or resource**, put your awesome item at the **BOTTOM** of the correct section.
  - If it's a **theme**, insert it according to the **ALPHABETICAL** order.
- [x] **Description:** I've written a short (one sentence) description for the addition in the `README.md`.
- [x] **Downloads:** I've added a download stats badge in the second column (`[![npm](https://img.shields.io/npm/dm/hyper-example.svg?label=DL)]()`)